### PR TITLE
Fix TcpReadWrite.hs.templing (incremental parsing)

### DIFF
--- a/src/gens/haskell/TcpReadWrite.hs.templing
+++ b/src/gens/haskell/TcpReadWrite.hs.templing
@@ -1,13 +1,21 @@
-import qualified Trans
-import Control.Monad
-import qualified Data.Binary as Bin
-import Data.Binary.Get (runGet)
-import Data.Binary.Put (runPut)
-import qualified Data.ByteString.Lazy as BS
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main where
+
+import qualified Control.Exception              as CE
+import           Control.Monad
+import           Data.Binary                    (Binary)
+import qualified Data.Binary                    as Binary
+import qualified Data.Binary.Get                as Binary
+import qualified Data.Binary.Put                as Binary
+import qualified Data.ByteString                as BS
+import qualified Data.ByteString.Lazy           as BSL
+import           Data.Maybe                     (catMaybes, isJust)
+import           Network.Socket
+import           Network.Socket.ByteString.Lazy as SBS
 import qualified System.Environment
-import qualified Control.Exception as CE
-import Network.Socket
-import Network.Socket.ByteString.Lazy as SBS
+import qualified Trans
+
 import {{ module_name(schema) }}
 
 runTCPClient :: HostName -> ServiceName -> (Socket -> IO a) -> IO a
@@ -28,20 +36,57 @@ main = do
     args <- System.Environment.getArgs
     let host = args !! 0
     let port = args !! 1
-    let stdout :: Bool = read $ args !! 2
+    let stdout :: Bool = (args !! 2) == "true"
     runTCPClient host port $ \socket -> do
         contents <- SBS.getContents socket
-        let models = runGet readModels contents
+        let models = readManyWithHasDataFlag Trans.read contents :: [{{ type_name(schema) }}]
         forM_ models $ \model -> do
             when stdout $ print model
-            SBS.sendAll socket (runPut $ Trans.write model)
-        where
-            readModels :: Bin.Get [{{ type_name(schema) }}]
-            readModels = do
-                hasData :: Bool <- Trans.read
-                if hasData then do
-                    x <- Trans.read
-                    xs <- readModels
-                    return (x:xs)
-                else
-                    return []
+            SBS.sendAll socket (Binary.runPut $ Trans.write model)
+
+-- | Parse a lazy 'BSL.ByteString' incrementally into a lazy list.
+--
+-- >>> take 10 (getManyIncremental Binary.getInt32host (BSL.cycle "1\NUL\NUL\NUL\NUL"))
+-- [49,12544,3211264,822083584,0,49,12544,3211264,822083584,0]
+getManyIncremental :: Binary.Get a -> BSL.ByteString -> [a]
+getManyIncremental get = go getOne . BSL.toChunks
+  where
+    getOne = Binary.runGetIncremental get
+
+    go (Binary.Fail _leftover _bytesRead err) _ = error err
+    go (Binary.Done leftover _bytesRead x) chunks = x :
+      if | null chunks && BS.null leftover -> []
+         | BS.null leftover                -> go getOne chunks
+         | otherwise                       -> go getOne (leftover : chunks)
+    go decoder [] = go (Binary.pushEndOfInput decoder) []
+    go decoder (chunk:chunks) = go (decoder `Binary.pushChunk` chunk) chunks
+
+-- | Parse a value preceded by a boolean flag, indicating if there is data to be parsed.
+--
+-- >>> Binary.runGet (readWithHasDataFlag Binary.getInt32host) "\x00"
+-- Nothing
+-- >>> Binary.runGet (readWithHasDataFlag Binary.getInt32host) "\x01\xFF\xFF\xFF\xFF"
+-- Just (-1)
+-- >>> Binary.runGet (readWithHasDataFlag Binary.getInt32host) "\x00\xFF\xFF\xFF\xFF"
+-- Nothing
+readWithHasDataFlag :: Binary.Get a -> Binary.Get (Maybe a)
+readWithHasDataFlag get = do
+  hasData <- Trans.read
+  if hasData
+     then Just <$> get
+     else return Nothing
+
+-- | Parse a lazy 'BSL.ByteString' incrementally into a lazy list of values.
+-- Each value is preceded by a boolean flag indicating that there is data.
+--
+-- >>> take 5 (readManyWithHasDataFlag Binary.getInt32host (BSL.cycle "\x01\xFF\xFF\xFF\xFF"))
+-- [-1,-1,-1,-1,-1]
+-- >>> readManyWithHasDataFlag Binary.getInt32host "\x01\xFF\xFF\xFF\xFF"
+-- [-1]
+-- >>> readManyWithHasDataFlag Binary.getInt32host "\x01\xFF\xFF\xFF\xFF\x00"
+-- [-1]
+-- >>> readManyWithHasDataFlag Binary.getInt32host "\x00\xFF\xFF\xFF\xFF\x00"
+-- []
+readManyWithHasDataFlag :: Binary.Get a -> BSL.ByteString -> [a]
+readManyWithHasDataFlag get
+  = catMaybes . takeWhile isJust . getManyIncremental (readWithHasDataFlag get)


### PR DESCRIPTION
Use incremental parsing, to produce the list of models in a lazy list.

```sh
cargo run --example testing -- --verbose --language Haskell --test TcpReadWrite --model example --code-path tmpdir
```
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/examples/testing --verbose --language Haskell --test TcpReadWrite --model example --code-path tmpdir`
Testing Haskell::example::TcpReadWrite
Copying from /.../trans-gen/tmpdir/.stack-work/install/x86_64-osx/cdbd0f53c886f7775564db06aa234cac3aa562435bb6b5e681ca5e52f682b9d3/8.10.3/bin/trans-gen-test to /.../trans-gen/tmpdir/bin/trans-gen-test

Copied executables to /.../trans-gen/tmpdir/bin:
- trans-gen-test

Warning: Installation path /.../trans-gen/tmpdir/bin
         not found on the PATH environment variable.
Build duration: 438 ms
Example {oneOf = OptionOne (OneOfOptionOne {vecInt32 = [1,2,3], longInt = 4611686018427387904}), hashMap = fromList [(ValueOne,5),(ValueTwo,6)], optionalInt = Just 100500, optionalBool = Nothing, optionalOneOf = Just (OptionTwo (OneOfOptionTwo {value = 123})), optionalStruct = Just (Structure {text = "Hello, world!", floatNumber = -50.234, doubleNumber = 123.456}), optionalEnum = Just ValueTwo}
Run duration: 7 ms (7 ms avg)
Test finished successfully
```